### PR TITLE
Add line continuation character to repo list

### DIFF
--- a/roles/fuse-standalone/templates/org.ops4j.pax.url.mvn.cfg.j2
+++ b/roles/fuse-standalone/templates/org.ops4j.pax.url.mvn.cfg.j2
@@ -102,7 +102,7 @@ org.ops4j.pax.url.mvn.defaultRepositories=\
 #    @noreleases : the repository does not contain any released artifacts
 #
 org.ops4j.pax.url.mvn.repositories= \
-    {{ maven_repository_manager_item | default("") | replace('\n', '') }}
+    {{ maven_repository_manager_item | default("") | replace('\n', '') }} \
     http://repo1.maven.org/maven2@id=maven.central.repo, \
     https://maven.repository.redhat.com/ga@id=redhat.ga.repo, \
     https://maven.repository.redhat.com/earlyaccess/all@id=redhat.ea.repo, \


### PR DESCRIPTION
Hi Roman, thanks for creating this playbook.

Adding a line continuation character `\` to `org.ops4j.pax.url.mvn.repositories`. Without this, the other repositories are assumed to be part of a different property, and ignored (meaning that Maven Central / RH repos / etc are never added to the repositories property).

Tom